### PR TITLE
fix: implement stock sorting in stock management

### DIFF
--- a/src/hooks/useStockManagement.ts
+++ b/src/hooks/useStockManagement.ts
@@ -90,37 +90,8 @@ export const useStockManagement = () => {
         filters,
       );
 
-      let productsToDisplay = response.data.products;
-
-      // Apply client-side sorting based on stock count
-      if (filters.sortBy) {
-        productsToDisplay = [...productsToDisplay].sort((a, b) => {
-          // Get stock for the selected store or total stock
-          const getStock = (product: AdminProduct) => {
-            if (filters.storeId && filters.storeId !== "all") {
-              // Find stock for specific store
-              const storeStock = product.storeStock?.find(
-                (s) => s.storeId === filters.storeId,
-              );
-              return storeStock?.stock || 0;
-            }
-            // Use total stock for "All Stores"
-            return product.totalStock || 0;
-          };
-
-          const stockA = getStock(a);
-          const stockB = getStock(b);
-
-          if (filters.sortBy === "stock-asc") {
-            return stockA - stockB; // Ascending: low to high
-          } else if (filters.sortBy === "stock-desc") {
-            return stockB - stockA; // Descending: high to low
-          }
-          return 0;
-        });
-      }
-
-      setProducts(productsToDisplay);
+      // Backend handles sorting, no need for client-side sorting
+      setProducts(response.data.products);
       setPagination(response.data.pagination);
     } catch (error) {
       console.error("Error loading products:", error);

--- a/src/services/admin/productAPI.ts
+++ b/src/services/admin/productAPI.ts
@@ -34,6 +34,7 @@ export const adminProductAPI = {
     if (filters?.search) params.append("search", filters.search);
     if (filters?.categoryId) params.append("categoryId", filters.categoryId);
     if (filters?.storeId) params.append("storeId", filters.storeId);
+    if (filters?.sortBy) params.append("sortBy", filters.sortBy);
     if (filters?.isActive !== undefined)
       params.append("isActive", filters.isActive.toString());
 

--- a/src/types/admin/product.ts
+++ b/src/types/admin/product.ts
@@ -123,6 +123,7 @@ export interface ProductFilters {
   categoryId?: string;
   storeId?: string;
   isActive?: boolean;
+  sortBy?: "stock-asc" | "stock-desc";
 }
 
 export interface CategoryFilters {


### PR DESCRIPTION
- Add sortBy parameter to ProductFilters type
- Pass sortBy to backend API in getProducts request
- Remove client-side sorting (now handled by backend)
- Enable proper sorting across all pages, not just current page